### PR TITLE
camera: Set default focus mode for better brightness.

### DIFF
--- a/app/src/main/java/com/minio/io/alice/CameraDeviceManager.java
+++ b/app/src/main/java/com/minio/io/alice/CameraDeviceManager.java
@@ -21,6 +21,7 @@
 package com.minio.io.alice;
 
 import android.content.Context;
+import android.hardware.Camera;
 import android.util.Log;
 
 import com.google.android.gms.vision.Detector;
@@ -98,6 +99,7 @@ public class CameraDeviceManager {
                 .setFacing(cameraId)
                 .setRequestedFps(25.0f)
                 .setFrameHandler(mframeHandler)
+                .setFocusMode(Camera.Parameters.FOCUS_MODE_MACRO)
                 .build();
     }
 


### PR DESCRIPTION
The default brightness that it gets from Camera.params is not bright enough on some phones. Fix this by selecting a FOCUS_MODE that works best for our needs.